### PR TITLE
CI: Removed check for compiler since its failing on linux

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-      - name: Configure CMake
+      - name: Configure CMake (Windows)
         if: matrix.os == 'windows-latest'
         run: >
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
@@ -66,7 +66,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -S ${{ github.workspace }}
 
-      - name: Configure CMake
+      - name: Configure CMake (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: >
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
@@ -74,10 +74,6 @@ jobs:
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -S ${{ github.workspace }}
-
-      - name: Print selected compiler
-        run: |
-          cmake -LAH -B ${{ steps.strings.outputs.build-output-dir }} | findstr "CMAKE_CXX_COMPILER"
 
       - name: Build
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.22)
 project(mantisapp VERSION 0.1.2)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
CMake: Downgraded minimum require version to 3.22 as recommended by GithubActions