### PR TITLE
ci: tag docker builds correctly if :rc, :beta, :alpha, etc

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,16 @@
 ## Workflows
 
 - **ci.yml** — Build and test on push/PR to `master` and `v0.3.x`. Uses `build-matrix.yml`.
-- **release.yml** — On tag push `v*`: build, create GitHub Release with assets, then build and push Docker image. Uses `build-matrix.yml` and `docker-publish.yml`.
+- **release.yml** — On tag push `v*`: build, create GitHub Release with assets, then build and push Docker image. Uses `build-matrix.yml` and `docker-publish.yml`. Stable tags (e.g. `v1.2.0`) create a normal GitHub Release and push Docker tags `{version}` and `latest`. Pre-release tags (e.g. `v1.2.0-beta.1`, `v1.2.0-alpha.1`, `v1.2.0-rc.1`) create a GitHub pre-release and push Docker tags `{version}` plus a moving channel tag (`alpha`, `beta`, or `rc`); they do not update `latest`.
 - **docs.yml** — Build Doxygen docs and publish to `gh-pages`. Triggered by tag push `v*` or manually via **Run workflow** (`workflow_dispatch`).
 - **build-matrix.yml** — Reusable: matrix build (Ubuntu/Windows), test, and on tag zip/upload artifacts.
-- **docker-publish.yml** — Reusable: build image from `docker/`, push to Docker Hub with version and `latest` tags.
+- **docker-publish.yml** — Reusable: build image from `docker/`, push to Docker Hub. Stable releases get `{version}` and `latest`; pre-releases get `{version}` and the channel tag (`alpha`, `beta`, or `rc`).
+
+## Release tag convention
+
+Use SemVer-style tags:
+
+- Stable: `v1.2.0` → Docker `1.2.0`, `latest`
+- Beta: `v1.2.0-beta.1` → Docker `1.2.0-beta.1`, `beta`
+- Alpha: `v1.2.0-alpha.1` → Docker `1.2.0-alpha.1`, `alpha`
+- RC: `v1.2.0-rc.1` → Docker `1.2.0-rc.1`, `rc`

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: 'mantisbase'
+      prerelease:
+        description: 'Whether this is a pre-release (true/false)'
+        required: false
+        type: string
+        default: 'false'
+      channel:
+        description: 'Pre-release channel (alpha, beta, rc)'
+        required: false
+        type: string
+        default: ''
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -41,6 +51,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set Docker tags
+        id: docker_tags
+        run: |
+          repo="${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}"
+          version="${{ steps.version.outputs.version }}"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:${version}"
+            if [ "${{ inputs.prerelease }}" = "true" ] && [ -n "${{ inputs.channel }}" ]; then
+              echo "${repo}:${{ inputs.channel }}"
+            elif [ "${{ inputs.prerelease }}" != "true" ]; then
+              echo "${repo}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -49,6 +75,4 @@ jobs:
           build-args: |
             MB_VERSION=${{ steps.version.outputs.version }}
           push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:latest
+          tags: ${{ steps.docker_tags.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      channel: ${{ steps.meta.outputs.channel }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -26,12 +29,27 @@ jobs:
       - name: Show artifact contents
         run: ls -lh ./artifacts/
 
+      - name: Classify tag
+        id: meta
+        run: |
+          tag="${{ github.ref_name }}"
+          version="${tag#v}"
+          if echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$'; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            channel=$(echo "$version" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+)\.[0-9]+$/\1/')
+            echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "channel=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           files: ./artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,6 +59,8 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       version: ${{ github.ref_name }}
+      prerelease: ${{ needs.release.outputs.prerelease }}
+      channel: ${{ needs.release.outputs.channel }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
With automated Docker builds, all Git tags are used in tagging the Docker builds correctly and adding the latest tags. This is not wholly correct since alpha/beta/RC builds should not be tagged as "latest" in Docker builds.

This PR fixes that, ensuring all pre-lease Git versions are tagged correctly on pushed Docker images.