### PR TITLE
docs: fix Linux embedding dependencies to match current CI deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ That's it! You now have a fully functional backend with authentication and acces
 
 **Dependencies (Linux only):**
 ```bash
-sudo apt-get install -y libzstd-dev libpq-dev
+sudo apt-get install -y libpq-dev uuid-dev
 ```
 
 ```bash
@@ -379,7 +379,7 @@ For full API documentation, visit [https://docs.mantisbase.dev](https://allankoe
 
 ## Requirements
 
-- **Linux**: GCC with C++20 support, libzstd-dev, libpq-dev (for PostgreSQL)
+- **Linux**: GCC with C++20 support, libpq-dev, uuid-dev (libpq for PostgreSQL)
 - **Windows**: MinGW v13+ with std::format support
 - **No external runtime dependencies** - everything is bundled
 

--- a/doc/05.embedding.md
+++ b/doc/05.embedding.md
@@ -15,12 +15,14 @@ MantisBase is designed as a lightweight C++ library that can be embedded directl
 
 ## Dependencies
 
-On Linux, MantisBase depends on ZSTD and libpq for PostgreSQL support:
+On Linux, building MantisBase requires **libpq** (PostgreSQL client) and **libuuid** development packages. These match what CI installs in `.github/workflows/build-matrix.yml`:
 
 ```shell
-sudo apt-get install -y libzstd-dev
-sudo apt install libpq-dev
+sudo apt-get update
+sudo apt-get install -y libpq-dev uuid-dev
 ```
+
+Runtime shared libraries on Debian/Ubuntu are `libpq5` and `libuuid1` (see `docker/Dockerfile`).
 
 ---
 

--- a/doc/QuickStart.md
+++ b/doc/QuickStart.md
@@ -42,7 +42,7 @@ The server starts on `http://localhost:7070`.
 
 **Linux Dependencies:**
 ```bash
-sudo apt-get install -y libzstd-dev libpq-dev
+sudo apt-get install -y libpq-dev uuid-dev
 ```
 
 ### Build from Source


### PR DESCRIPTION
## Summary

Linux dependency docs still told embedders to install `libzstd-dev` + `libpq-dev`, but current CI (`.github/workflows/build-matrix.yml`) installs `libpq-dev` + `uuid-dev`, and the Docker image links `libpq5` + `libuuid1`. `uuid` was missing from the embedding guide entirely.

Update:

- `doc/05.embedding.md` (primary embedding deps)
- `doc/QuickStart.md`
- `README.md` (build-from-source + Requirements)

to:

```bash
sudo apt-get install -y libpq-dev uuid-dev
```

## Test plan

- [x] Docs only; packages match CI install step and Docker runtime deps
- [x] No code/build changes

Fixes #148